### PR TITLE
Fix --max-wait-for-slow-query type

### DIFF
--- a/core/commands/copy.py
+++ b/core/commands/copy.py
@@ -195,6 +195,7 @@ class Copy(CommandBase):
                             help="Raise an exception if the schema looks "
                             "different from the one in file after execution")
         parser.add_argument("--max-wait-for-slow-query",
+                            type=int,
                             help="How many attempts with 5 seconds sleep "
                             "in between we should have waited for "
                             "slow query to finish before error out")


### PR DESCRIPTION
Argparse will create it as `str`, but it has to be `int`.

Fixes: #21