### PR TITLE
Test DDL files decode-ability

### DIFF
--- a/core/commands/base.py
+++ b/core/commands/base.py
@@ -95,8 +95,9 @@ class CommandBase(object):
                             help="MySQL user password to connect to the "
                             "instance",
                             required=require_password)
-        parser.add_argument("--charset",
-                            help="Character set used for MySQL connection")
+        parser.add_argument("--charset", default='ascii',
+                            help="Character set used for MySQL connection "
+                            "(defaults to '%(default)s').")
         parser.add_argument("--force",
                             help="Ignore non-critical errors and continue "
                             "making schema changes for all the given "

--- a/core/commands/copy.py
+++ b/core/commands/copy.py
@@ -215,11 +215,20 @@ class Copy(CommandBase):
                 raise OSCError('OUTFILE_DIR_NOT_DIR',
                                {'dir': self.args.outfile_dir})
 
-        # Ensure all the given ddl files are readable
+        # Ensure all the given ddl files are readable and
+        # can be decoded with the current charset
         for filepath in self.args.ddl_file_list:
             if not util.is_file_readable(filepath):
                 raise OSCError('FAILED_TO_READ_DDL_FILE',
                                {'filepath': filepath})
+            charset = getattr(self.args, 'charset')
+            try:
+                with open(filepath, 'r') as file_obj:
+                    file_obj.read().decode(charset)
+            except UnicodeDecodeError:
+                raise OSCError('FAILED_TO_DECODE_DDL_FILE',
+                               {'filepath': filepath,
+                                'charset': charset})
 
     def op(self, sudo=False):
         self.payload = CopyPayload(get_conn_func=self.get_conn_func,

--- a/core/lib/error.py
+++ b/core/lib/error.py
@@ -279,6 +279,13 @@ class OSCError(Exception):
                 '`SHOW CREATE TABLE`. Difference detected: \n {diff}'
             )
         },
+        'FAILED_TO_DECODE_DDL_FILE': {
+            'code': 150,
+            'desc': (
+                "Failed to decode DDL file '{filepath}' "
+                "with charset '{charset}'. Use --charset "
+                "to set the proper charset."),
+        },
         'ASSERTION_ERROR': {
             'code': 249,
             'desc': (


### PR DESCRIPTION
Check whether the file can be decoded or not by the current charset.

Fixes: #15 