### PR TITLE
Fixing Travis tests (for real)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,23 @@
 language: python
 
-service:
+dist: trusty
+
+services:
   - mysql
 
 python:
-  - 3.4
   - 3.5
   - 3.6
-  - 3.7
 
 before_install:
-  - sudo apt-get install python3-dev
-
-before_script:
-  - mysql -e 'create database if not exists test'
-  - mysql -u root -e 'grant all on *.* to "osc"@"localhost" identified by "osc"'
-  - echo -e "[server]\nsocket=/tmp/mysql.sock" | sudo tee -a /etc/mysql/my.cnf
-  - sudo service mysql restart
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
+  - mysql -e 'GRANT ALL ON *.* TO "osc"@"localhost" IDENTIFIED BY "osc";'
   - sudo chmod 777 -R /var/lib/mysql
-  - pip install -U docutils pygments
 
 install:
   - python3 setup.py install
+  - pip3 install -U docutils pygments
 
 script:
-   # bug in distutils prevents check -r -s passing, Python 3.3 on Travis is too old to include the fix:
-   # https://github.com/travis-ci/travis-ci/issues/7028#issuecomment-267115326
   - python3 setup.py check -r -s
-  - cd $TRAVIS_BUILD_DIR && ./test_cli --mysql-user=osc --mysql-password=osc --database test --socket=/tmp/mysql.sock
+  - cd $TRAVIS_BUILD_DIR && ./test_cli --mysql-user=osc --mysql-password=osc --database test --socket=/var/run/mysqld/mysqld.sock

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ OnlineSchemaChange requires
     sudo apt-get install python3-dev # debian / Ubuntu
     sudo yum install python3-devel # Red Hat / CentOS
 
-**Python requirements** \* python >= 3.4 \* python module:
+**Python requirements** \* python >= 3.5 \* python module:
 `pyparsing <http://pyparsing.wikispaces.com/>`__,
 `MySQLdb <http://github.com/PyMySQL/mysqlclient-python/tarball/master>`__
 

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     scripts=['osc_cli'],
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.4',
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
* fix typo in "services" parameter in .travis.yml
* remove python3.4, since it's no longer supported by mysql python client:
    https://github.com/PyMySQL/mysqlclient-python/issues/342
* use trusty image, because it provides mysql-server-5.6
* remove python-3.7 because it's no supported in trusty
* package python3-dev is installed by default in travis images
* no need to restart mysql service